### PR TITLE
Change project, task, task type delimiter to variable

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -513,15 +513,12 @@ function getTaskInfoFromDateEntry(projectTaskTimeTypeHash) {
 
 function selectOptionForControl(selectCtrl, optionValue) {
     let matchingElement;
-    // We want to make sure that the options property _exists_ before we look for anything to do with it
-    if (selectCtrl.options) {
-        // Iterate through the various options that may exist, and look for the one we care about
-        for (let i = 0, optionsLength = selectCtrl.options.length; i < optionsLength; i++) {
-            if (selectCtrl.options[i].textContent.indexOf(optionValue) > -1) {
-                selectCtrl.selectedIndex = i;
-                matchingElement = selectCtrl.options[i];
-                break;
-            }
+
+    for (let i = 0, optionsLength = selectCtrl.options.length; i < optionsLength; i++) {
+        if (selectCtrl.options[i].textContent.indexOf(optionValue) > -1) {
+            selectCtrl.selectedIndex = i;
+            matchingElement = selectCtrl.options[i];
+            break;
         }
     }
 

--- a/contentscript.js
+++ b/contentscript.js
@@ -513,12 +513,15 @@ function getTaskInfoFromDateEntry(projectTaskTimeTypeHash) {
 
 function selectOptionForControl(selectCtrl, optionValue) {
     let matchingElement;
-
-    for (let i = 0, optionsLength = selectCtrl.options.length; i < optionsLength; i++) {
-        if (selectCtrl.options[i].textContent.indexOf(optionValue) > -1) {
-            selectCtrl.selectedIndex = i;
-            matchingElement = selectCtrl.options[i];
-            break;
+    // We want to make sure that the options property _exists_ before we look for anything to do with it
+    if (selectCtrl.options) {
+        // Iterate through the various options that may exist, and look for the one we care about
+        for (let i = 0, optionsLength = selectCtrl.options.length; i < optionsLength; i++) {
+            if (selectCtrl.options[i].textContent.indexOf(optionValue) > -1) {
+                selectCtrl.selectedIndex = i;
+                matchingElement = selectCtrl.options[i];
+                break;
+            }
         }
     }
 

--- a/contentscript.js
+++ b/contentscript.js
@@ -7,6 +7,8 @@ var elements = {
 
 var controls = getControls();
 
+const delim = "||||".toString()
+
 function getControls() {
 
     return getOldUIControls();
@@ -407,7 +409,7 @@ function getProjectTaskTimeTypeRowMappings() {
 }
 
 function getProjectTaskTimeTypeHash(project, task, timeType) {
-    return project + "|" + task + "|" + timeType;
+    return project + delim + task + delim + timeType;
 }
 
 function findProjectTaskTimeTypeRow(mappings, project, alternateProject, task, alternateTask, timeType) {
@@ -491,7 +493,7 @@ function createTimesheet(timesheetData, roundTime, descriptionField) {
 }
 
 function getTaskInfoFromDateEntry(projectTaskTimeTypeHash) {
-    let hashPieces = projectTaskTimeTypeHash.split("|");
+    let hashPieces = projectTaskTimeTypeHash.split(delim.toString());
 
     // Used to find tasks that are labeled Billable
     // E.g. Billable task, billable task, my task - billable, my task [Billable]

--- a/popup.js
+++ b/popup.js
@@ -3,6 +3,7 @@ var descriptionFieldEnum = { description: 0, notes: 1, both: 2, none: 3 };
 
 var cancellationToken;
 
+var delim = "||||".toString()
 function startPromiseTransaction() {
     cancellationToken = false;
 }
@@ -813,9 +814,9 @@ function getTogglTimeEntries(apiKey, userId, workspaceId, startDate, endDate) {
 
 function generateAggregateKey(entry, groupByTask) {
     if (groupByTask) {
-        return entry.client + "|" + entry.project + "|" + entry.is_billable.toString();
+        return entry.client + delim + entry.project + delim + entry.is_billable.toString();
     } else {
-        return entry.client + "|" + entry.project + "|" + entry.is_billable.toString() + "|" + entry.description;
+        return entry.client + delim + entry.project + delim + entry.is_billable.toString() + delim + entry.description;
     }
 }
 


### PR DESCRIPTION
This will move the hard-coded deliminators up to a variable and extend it to 4 `|`'s instead of a single one. This will help avoid situations where a project or task name has the `|` character, causing the parsing of the time entry to fail.