### PR TITLE
Check to see if options exist before getting length

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -511,12 +511,14 @@ function getTaskInfoFromDateEntry(projectTaskTimeTypeHash) {
 
 function selectOptionForControl(selectCtrl, optionValue) {
     let matchingElement;
-
-    for (let i = 0, optionsLength = selectCtrl.options.length; i < optionsLength; i++) {
-        if (selectCtrl.options[i].textContent.indexOf(optionValue) > -1) {
-            selectCtrl.selectedIndex = i;
-            matchingElement = selectCtrl.options[i];
-            break;
+    // Check to see if options exist before getting the length
+    if (selectCtrl.options) {
+        for (let i = 0, optionsLength = selectCtrl.options.length; i < optionsLength; i++) {
+            if (selectCtrl.options[i].textContent.indexOf(optionValue) > -1) {
+                selectCtrl.selectedIndex = i;
+                matchingElement = selectCtrl.options[i];
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Add a check to make sure options exist before getting the length of said options. This should resolve an issue where the "Task Type" dropdown does not exist, in addition to situations when the extension will attempt to check for options when they don't exist.